### PR TITLE
Add support for specifying include/exclude paths for git lfs pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,23 @@ Set the following environment variable for your app:
   username, password, or personal access token which is necessary to
   clone noninteractively. See [here][noninteractive-clone] for
   details on the syntax. It must be something like `git@github.com:BureauxLocaux/my-repo`
-* `BL_BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY`: your private key encoded in base64 with `base64 -w 0`. You can use `heroku config:set --app preprod-bureauxlocaux "BL_BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY=$(cat ~/.ssh/heroku_deploy_lfs | base64 -w 0)"` to set it.
+* `BL_BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY`: your private key encoded in base64 with `base64 -w 0`. You
+  can use `heroku config:set --app preprod-bureauxlocaux "BL_BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY=$(cat
+  ~/.ssh/heroku_deploy_lfs | base64 -w 0)"` to set it.
+* `BL_BUILDPACK_GIT_LFS_INCLUDE_PATHS`: (OPTIONAL) a comma-separated list of (relative) paths to
+  include in the fetch. Passed via the `--include` flag to `git lfs pull`
+* `BL_BUILDPACK_GIT_LFS_EXCLUDE_PATHS`: (OPTIONAL) a comma-separated list of (relative) paths to
+  exclude in the fetch. Passed via the `--exclude` flag to `git lfs pull`
+
 
 After the next time you deploy your app, Git LFS assets will be
 downloaded and checked out automatically, and Git LFS will be
 available on `PATH` for your app.
 
-Inspiration was taken from [the original repo](https://github.com/raxod502/heroku-buildpack-git-lfs) and [a buildpack to use SSH keys][git-ssh-key-buildpack]. This repository allows you to rely on deploy SSH keys to pull LFS files instead of requiring tokens.
+Inspiration was taken from [the original repo](https://github.com/raxod502/heroku-buildpack-git-lfs)
+and [a buildpack to use SSH keys][git-ssh-key-buildpack]. This repository allows you to rely on
+deploy SSH keys to pull LFS files instead of requiring tokens. Also, added support to optionally
+specify relative paths of files to include/exclude when fetching lfs objects.
 
 [buildpacks]: https://devcenter.heroku.com/articles/buildpacks
 [git-lfs]: https://git-lfs.github.com/

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ To configure Git LFS for your Heroku app called `<myapp>`, run:
 
 Set the following environment variable for your app:
 
-* `BL_BUILDPACK_GIT_LFS_REPO` to the clone URL of the repository
+* `BUILDPACK_GIT_LFS_REPO` to the clone URL of the repository
   from which to download Git LFS assets. This should include any
   username, password, or personal access token which is necessary to
   clone noninteractively. See [here][noninteractive-clone] for
-  details on the syntax. It must be something like `git@github.com:BureauxLocaux/my-repo`
-* `BL_BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY`: your private key encoded in base64 with `base64 -w 0`. You
-  can use `heroku config:set --app preprod-bureauxlocaux "BL_BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY=$(cat
+  details on the syntax. It must be something like `git@github.com:remix/remix`
+* `BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY`: your private key encoded in base64 with `base64 -w 0`. You
+  can use `heroku config:set --app preprod-bureauxlocaux "BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY=$(cat
   ~/.ssh/heroku_deploy_lfs | base64 -w 0)"` to set it.
-* `BL_BUILDPACK_GIT_LFS_INCLUDE_PATHS`: (OPTIONAL) a comma-separated list of (relative) paths to
+* `BUILDPACK_GIT_LFS_INCLUDE_PATHS`: (OPTIONAL) a comma-separated list of (relative) paths to
   include in the fetch. Passed via the `--include` flag to `git lfs pull`
-* `BL_BUILDPACK_GIT_LFS_EXCLUDE_PATHS`: (OPTIONAL) a comma-separated list of (relative) paths to
+* `BUILDPACK_GIT_LFS_EXCLUDE_PATHS`: (OPTIONAL) a comma-separated list of (relative) paths to
   exclude in the fetch. Passed via the `--exclude` flag to `git lfs pull`
 
 

--- a/bin/compile
+++ b/bin/compile
@@ -29,6 +29,25 @@ else
     die "Env var BL_BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY is not set"
 fi
 
+include_paths=""
+if [[ -f "$env_dir/BL_BUILDPACK_GIT_LFS_INCLUDE_PATHS" ]]; then
+    include_paths="--include=$(< "$env_dir/BL_BUILDPACK_GIT_LFS_INCLUDE_PATHS")"
+fi
+
+exclude_paths=""
+if [[ -f "$env_dir/BL_BUILDPACK_GIT_LFS_EXCLUDE_PATHS" ]]; then
+    exclude_paths="--exclude=$(< "$env_dir/BL_BUILDPACK_GIT_LFS_EXCLUDE_PATHS")"
+fi
+
+echo "-----> Install Git LFS"
+(
+    pushd /tmp
+    wget https://github.com/git-lfs/git-lfs/releases/download/v2.11.0/git-lfs-linux-amd64-v2.11.0.tar.gz \
+         -O git-lfs.tar.gz
+    tar -xvzf /tmp/git-lfs.tar.gz
+    popd
+) | indent
+
 git_user="${repo%@*}"
 git_host="${repo#*@}"
 git_host="${git_host%:*}"
@@ -36,6 +55,15 @@ git_host="${git_host%:*}"
 echo "-----> Download Git LFS assets"
 (
     pushd "$build_dir"
+
+    mkdir -p .heroku/bin
+    mv /tmp/git-lfs .heroku/bin/
+
+    mkdir -p .profile.d
+    cat <<"EOF" > .profile.d/heroku-buildpack-git-lfs.sh
+export PATH="$HOME/.heroku/bin:$PATH"
+EOF
+    export PATH="$build_dir/.heroku/bin:$PATH"
 
     mkdir -p /app/.ssh
     chmod 700 /app/.ssh
@@ -57,6 +85,9 @@ echo "-----> Download Git LFS assets"
     git fetch origin
     git reset --mixed "$SOURCE_VERSION"
     git lfs install
-    git lfs pull
+    # Monorepo compatibility - only pull large files in the sub-project of the monorepo
+    git lfs pull "$include_paths" "$exclude_paths"
+
     rm -rf .git
+    rm -rf /app/.ssh
 ) | indent

--- a/bin/compile
+++ b/bin/compile
@@ -17,26 +17,26 @@ function indent {
     sed -u 's/^/       /'
 }
 
-if [[ -f "$env_dir/BL_BUILDPACK_GIT_LFS_REPO" ]]; then
-    repo="$(< "$env_dir/BL_BUILDPACK_GIT_LFS_REPO")"
+if [[ -f "$env_dir/BUILDPACK_GIT_LFS_REPO" ]]; then
+    repo="$(< "$env_dir/BUILDPACK_GIT_LFS_REPO")"
 else
-    die "Env var BL_BUILDPACK_GIT_LFS_REPO is not set"
+    die "Env var BUILDPACK_GIT_LFS_REPO is not set"
 fi
 
-if [[ -f "$env_dir/BL_BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY" ]]; then
-    ssh_key="$(< "$env_dir/BL_BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY")"
+if [[ -f "$env_dir/BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY" ]]; then
+    ssh_key="$(< "$env_dir/BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY")"
 else
-    die "Env var BL_BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY is not set"
+    die "Env var BUILDPACK_GIT_LFS_SSH_PRIVATE_KEY is not set"
 fi
 
 include_paths=""
-if [[ -f "$env_dir/BL_BUILDPACK_GIT_LFS_INCLUDE_PATHS" ]]; then
-    include_paths="--include=$(< "$env_dir/BL_BUILDPACK_GIT_LFS_INCLUDE_PATHS")"
+if [[ -f "$env_dir/BUILDPACK_GIT_LFS_INCLUDE_PATHS" ]]; then
+    include_paths="--include=$(< "$env_dir/BUILDPACK_GIT_LFS_INCLUDE_PATHS")"
 fi
 
 exclude_paths=""
-if [[ -f "$env_dir/BL_BUILDPACK_GIT_LFS_EXCLUDE_PATHS" ]]; then
-    exclude_paths="--exclude=$(< "$env_dir/BL_BUILDPACK_GIT_LFS_EXCLUDE_PATHS")"
+if [[ -f "$env_dir/BUILDPACK_GIT_LFS_EXCLUDE_PATHS" ]]; then
+    exclude_paths="--exclude=$(< "$env_dir/BUILDPACK_GIT_LFS_EXCLUDE_PATHS")"
 fi
 
 echo "-----> Install Git LFS"

--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ fi
 echo "-----> Install Git LFS"
 (
     pushd /tmp
-    wget https://github.com/git-lfs/git-lfs/releases/download/v2.11.0/git-lfs-linux-amd64-v2.11.0.tar.gz \
+    wget -nv https://github.com/git-lfs/git-lfs/releases/download/v2.11.0/git-lfs-linux-amd64-v2.11.0.tar.gz \
          -O git-lfs.tar.gz
     tar -xvzf /tmp/git-lfs.tar.gz
     popd
@@ -52,7 +52,7 @@ git_user="${repo%@*}"
 git_host="${repo#*@}"
 git_host="${git_host%:*}"
 
-echo "-----> Download Git LFS assets"
+echo "-----> Download Git LFS assets ($SOURCE_VERSION)"
 (
     pushd "$build_dir"
 
@@ -82,8 +82,8 @@ EOF
 
     git init
     git remote add origin "$repo"
-    git fetch origin
-    git reset --mixed "$SOURCE_VERSION"
+    git fetch -q origin
+    git reset -q --mixed "$SOURCE_VERSION"
     git lfs install
     # Monorepo compatibility - only pull large files in the sub-project of the monorepo
     git lfs pull "$include_paths" "$exclude_paths"


### PR DESCRIPTION
Because we build from a monorepo, we don't want to pull all lfs objects. So
instead, support optional env vars to specify file paths to include/exclude.

Also, since we'll need to run this before running the Apt buildpack, add back in
support for installing git-lfs directly.